### PR TITLE
Fix bugs related to Frodo Exiting

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -53,6 +53,9 @@ const { initTokenCache } = frodo.cache;
 process.noDeprecation = true;
 process.argv = normalizeExpandedHelpArgv(process.argv);
 
+// Override SIGINT (ctrl+c) to exit the program immediately. Exit code 130 is normally associated with SIGINT.
+process.on('SIGINT', () => process.exit(130));
+
 (async () => {
   try {
     // override default library output handlers with our own


### PR DESCRIPTION
This PR fixes a few bugs with Frodo not exiting correctly. 

First is an issue where pressing ctrl+C would not immediately end execution. This is now fixed.

Second is an issue where Frodo would exit with an incorrect status code (success code) when the help screen is displayed in the event of an error. This is now fixed as well.